### PR TITLE
Support Supabase publishable key auth in frontend API client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Never use your Supabase service_role key in frontend code.
+# Optional Supabase configuration overrides.
+# If omitted, the app falls back to values in utils/supabase/info.tsx
+VITE_SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
+
+# Use one of these (anon JWT OR new publishable key format)
+VITE_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY
+# VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_xxx
+
+VITE_SUPABASE_FUNCTION_NAME=make-server

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# dependencies and build output
+node_modules/
+dist/
+
+# local env overrides (can contain secrets)
+.env
+.env.local
+.env.*.local
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ Your login is currently failing because the Supabase database needs to be initia
 
 Just log in or create an account to start tracking your study sessions!
 
+### Use Your Own Supabase Project (Optional)
+
+If you want to connect this app to your own Supabase project:
+
+1. Copy `.env.example` to `.env`
+2. Fill in `VITE_SUPABASE_URL` and either `VITE_SUPABASE_ANON_KEY` or `VITE_SUPABASE_PUBLISHABLE_KEY` from your Supabase project settings
+3. Keep `VITE_SUPABASE_FUNCTION_NAME=make-server` unless you renamed the function
+4. Restart the dev server
+
+### Security Tip (Important)
+
+You can safely use the **Supabase anon key** in frontend apps.
+
+- ✅ OK to use in this app: `VITE_SUPABASE_ANON_KEY` or `VITE_SUPABASE_PUBLISHABLE_KEY`
+- ❌ Never put in frontend code: **service_role key**
+
+Keep your real values in `.env` (which is now gitignored) so they are not accidentally committed.
+
 ## ✨ Features
 
 - **Multi-User Support**: Real-time leaderboard showing all registered users

--- a/src/app/utils/api.ts
+++ b/src/app/utils/api.ts
@@ -2,7 +2,11 @@
 import { projectId, publicAnonKey } from '../../../utils/supabase/info';
 import { localStorageApi } from '../lib/storage-fallback';
 
-const API_BASE_URL = `https://${projectId}.supabase.co/functions/v1/make-server`;
+const env = import.meta.env;
+const supabaseUrl = env.VITE_SUPABASE_URL || `https://${projectId}.supabase.co`;
+const apiKey = env.VITE_SUPABASE_ANON_KEY || env.VITE_SUPABASE_PUBLISHABLE_KEY || publicAnonKey;
+const functionName = env.VITE_SUPABASE_FUNCTION_NAME || 'make-server';
+const API_BASE_URL = `${supabaseUrl}/functions/v1/${functionName}`;
 
 // Connection mode tracking
 let useOnlineMode = false; // Start in offline mode by default
@@ -18,7 +22,8 @@ export async function checkConnection(): Promise<boolean> {
   try {
     const response = await fetch(`${API_BASE_URL}/health`, {
       headers: {
-        'Authorization': `Bearer ${publicAnonKey}`,
+        'Authorization': `Bearer ${apiKey}`,
+        'apikey': apiKey,
       },
       signal: AbortSignal.timeout(3000), // 3 second timeout
     });
@@ -101,7 +106,8 @@ async function apiRequest<T>(
       ...options,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${publicAnonKey}`,
+        'Authorization': `Bearer ${apiKey}`,
+        'apikey': apiKey,
         ...options.headers,
       },
     });


### PR DESCRIPTION
### Motivation

- Allow the frontend to authenticate to Supabase Edge Functions using either the legacy anon JWT or the newer publishable key format so users can point the app at their own Supabase project.
- Ensure Edge Function requests include the `apikey` header in addition to `Authorization` for better compatibility with Supabase auth expectations.

### Description

- Updated `src/app/utils/api.ts` to read `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_SUPABASE_PUBLISHABLE_KEY`, and `VITE_SUPABASE_FUNCTION_NAME`, build `API_BASE_URL` dynamically, and fall back to `projectId`/`publicAnonKey` when env vars are not provided.
- Use a resolved `apiKey` for requests and include it in both the `Authorization: Bearer` header and an `apikey` header for the health check and all `apiRequest` calls.
- Added/updated `.env.example` to document both supported key formats and keep a strong warning not to use the `service_role` key in client code.
- Updated `README.md` setup and security notes to instruct users to provide either `VITE_SUPABASE_ANON_KEY` or `VITE_SUPABASE_PUBLISHABLE_KEY` and to restart the dev server after changes.

### Testing

- Ran `npm run build` and the Vite production build completed successfully without errors.
- The code compiles against TypeScript and the updated `src/app/utils/api.ts` was included in the build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69892eea26748323987390ff9d3f5ddc)